### PR TITLE
Devops | No-Ticket | Automate NPM Release on merge to Master

### DIFF
--- a/.github/workflows/pr-label-validate.yml
+++ b/.github/workflows/pr-label-validate.yml
@@ -1,0 +1,22 @@
+name: 'Pull Request Version Label Validate'
+on:
+  pull_request:
+    branches:
+      - master
+    types:
+      - reopened
+      - labeled
+      - unlabeled
+jobs:
+  check_labels:
+    name: 'Check PR Version Labels'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: mheap/github-action-required-labels@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          mode: exactly
+          count: 1
+          labels: 'major, minor, patch'

--- a/.github/workflows/pr-publish-on-merge.yml
+++ b/.github/workflows/pr-publish-on-merge.yml
@@ -1,0 +1,44 @@
+name: 'NPM Release on Merge'
+on:
+  pull_request:
+    branches:
+      - master
+    types:
+      - closed
+jobs:
+  merge_pr:
+    name: 'PR Merged'
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GH_ORG_PAT }}
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16.x'
+          cache: 'npm'
+      - name: Git config
+        run: |
+          git config --global user.email "${{ secrets.GH_ORG_EMAIL }}"
+          git config --global user.name "${{ secrets.GH_ORG_NAME }}"
+      - name: Apply version bump (major)
+        if: contains(github.event.pull_request.labels.*.name, 'major')
+        run: npm version major
+      - name: Apply version bump (minor)
+        if: contains(github.event.pull_request.labels.*.name, 'minor')
+        run: npm version minor
+      - name: Apply version bump (patch)
+        if: contains(github.event.pull_request.labels.*.name, 'patch')
+        run: npm version patch
+      - name: Git push version bump
+        run: git push origin master --follow-tags --force
+      - name: Authenticate with private NPM package
+        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
+      - name: Publish package
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - id: set-version
+        name: Output version change
+        run: npm pkg get version

--- a/.github/workflows/pr-version-label.yml
+++ b/.github/workflows/pr-version-label.yml
@@ -1,0 +1,16 @@
+name: 'Pull Request Version Label'
+on:
+  pull_request:
+    branches:
+      - master
+    types:
+      - opened
+jobs:
+  add_comment:
+    name: 'Add Version Label Comment'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mshick/add-pr-comment@v1
+        with:
+          message: Please set a versioning label of either `major`, `minor`, or `patch` to the pull request.
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Creates automated workflows for NPM Release when merging a PR to master, will update the version based on the tag provided: `patch`, `minor`, `major`
